### PR TITLE
fix(blobs): lighter blob size check for backwards compatibility

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -464,7 +464,7 @@ func byzantineDecideProposalFunc(ctx context.Context, t *testing.T, height int64
 	block1, blockParts1, propBlockID, blob := createProposalBlockAndBlob(t, cs)
 
 	blobParts := types.NewPartSetFromData(blob, types.PartSizeBytes)
-	blobID    := types.BlobID{
+	blobID := types.BlobID{
 		Hash:          blob.Hash(),
 		PartSetHeader: blobParts.Header(),
 	}

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -272,7 +272,7 @@ func decideProposal(
 	round int32,
 ) (*types.Proposal, *types.Block, types.Blob) {
 	cs1.mtx.Lock()
-	block, _, propBlockID, blob := createProposalBlockAndBlob(t, cs1)
+	block, _, _, blob := createProposalBlockAndBlob(t, cs1)
 	blockParts, err := block.MakePartSet(types.PartSizeBytes)
 	require.NoError(t, err)
 	validRound := cs1.ValidRound

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/cometbft/cometbft/mempool"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cometbft/cometbft/mempool"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/types/params.go
+++ b/types/params.go
@@ -183,9 +183,6 @@ func (params ConsensusParams) ValidateBasic() error {
 			params.Block.MaxGas)
 	}
 
-	if params.Blob.MaxBytes == 0 {
-		return errors.New("blob.MaxBytes cannot be 0")
-	}
 	if params.Blob.MaxBytes < -1 {
 		return fmt.Errorf("blob.MaxBytes must be -1 or greater than 0. Got %d",
 			params.Blob.MaxBytes)

--- a/types/params_test.go
+++ b/types/params_test.go
@@ -42,7 +42,7 @@ func TestConsensusParamsValidation(t *testing.T) {
 		13: {makeParams(-1, 0, 1, 2, 0, valEd25519, 0), true},
 		14: {makeParams(-2, 0, 1, 2, 0, valEd25519, 0), false},
 		// test blob params
-		15: {makeParams(1, 0, 0, 2, 0, valEd25519, 0), false},
+		15: {makeParams(1, 0, 0, 2, 0, valEd25519, 0), true},
 		16: {makeParams(1, 0, 80*1024, 2, 0, valEd25519, 0), true},
 		17: {makeParams(1, 0, 10, 2, 0, valEd25519, 0), true},
 		18: {makeParams(1, 0, 800*1024, 2, 0, valEd25519, 0), true},


### PR DESCRIPTION
This fix allows blobs to not be present in genesis.json. Zero blob size means that even if a proposer wants to propose blobs, it cannot attach any to the proposal. (blobs are disabled)

A governance vote can enable blobs by changing the value to maxBlobSizeBytes (or something else).

> Edit: added the linter fixes that didn't make it into PR#17 at the last minute.

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

