### PR TITLE
feat(tooling): Add script to prune node offline

### DIFF
--- a/cmd/prune-blocks/main.go
+++ b/cmd/prune-blocks/main.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	dbm "github.com/cometbft/cometbft-db"
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/state"
+	blockidxkv "github.com/cometbft/cometbft/state/indexer/block/kv"
+	"github.com/cometbft/cometbft/state/txindex/kv"
+	"github.com/cometbft/cometbft/store"
+)
+
+func main() {
+	var (
+		height        int64
+		dataDir       string
+		dbBackend     string
+		pruneIndexers bool
+	)
+
+	flag.Int64Var(&height, "height", 0, "Height to prune up to (not including this height)")
+	flag.StringVar(&dataDir, "data-dir", "", "Path to the data directory (default: $HOME/.cometbft/data)")
+	flag.StringVar(&dbBackend, "db-backend", "goleveldb", "Database backend type (goleveldb, cleveldb, boltdb, rocksdb, badgerdb)")
+	flag.BoolVar(&pruneIndexers, "prune-indexers", false, "Also prune tx and block indexers")
+	flag.Parse()
+
+	if height <= 0 {
+		fmt.Fprintln(os.Stderr, "Error: height must be greater than 0")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	// Set default data directory if not provided
+	if dataDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to get home directory: %v\n", err)
+			os.Exit(1)
+		}
+		dataDir = filepath.Join(homeDir, ".cometbft", "data")
+	}
+
+	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
+
+	// Check if databases exist
+	blockstoreDBPath := filepath.Join(dataDir, "blockstore.db")
+	stateDBPath := filepath.Join(dataDir, "state.db")
+
+	if _, err := os.Stat(blockstoreDBPath); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: blockstore.db not found in %s\n", dataDir)
+		os.Exit(1)
+	}
+
+	if _, err := os.Stat(stateDBPath); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: state.db not found in %s\n", dataDir)
+		os.Exit(1)
+	}
+
+	// Open blockstore database
+	logger.Info("Opening blockstore database", "path", blockstoreDBPath)
+	dbType := dbm.BackendType(dbBackend)
+	blockStoreDB, err := dbm.NewDB("blockstore", dbType, dataDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to open blockstore database: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := blockStoreDB.Close(); err != nil {
+			logger.Error("Failed to close blockstore database", "err", err)
+		} else {
+			logger.Info("Blockstore database closed")
+		}
+	}()
+
+	blockStore := store.NewBlockStore(blockStoreDB)
+	// Open state database
+	logger.Info("Opening state database", "path", stateDBPath)
+	stateDB, err := dbm.NewDB("state", dbType, dataDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to open state database: %v\n", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := stateDB.Close(); err != nil {
+			logger.Error("Failed to close state database", "err", err)
+		} else {
+			logger.Info("State database closed")
+		}
+	}()
+
+	stateStore := state.NewStore(stateDB, state.StoreOptions{})
+
+	var txIndexDB dbm.DB
+	var txIndexer *kv.TxIndex
+	var blockIndexer *blockidxkv.BlockerIndexer
+
+	// Only open tx_index database if pruning indexers
+	if pruneIndexers {
+		logger.Info("Opening tx_index database")
+		txIndexDB, err = dbm.NewDB("tx_index", dbType, dataDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to open tx_index database: %v\n", err)
+			os.Exit(1)
+		}
+		defer func() {
+			if err := txIndexDB.Close(); err != nil {
+				logger.Error("Failed to close tx_index database", "err", err)
+			} else {
+				logger.Info("tx_index database closed")
+			}
+		}()
+
+		// Create indexers
+		txIndexer = kv.NewTxIndex(txIndexDB)
+		blockIndexer = blockidxkv.New(dbm.NewPrefixDB(txIndexDB, []byte("block_events")))
+	}
+
+	// Get current block store information
+	base := blockStore.Base()
+	currentHeight := blockStore.Height()
+
+	logger.Info("Block store information",
+		"base", base,
+		"height", currentHeight,
+		"requestedRetainHeight", height,
+	)
+
+	// Validate height
+	if height <= base {
+		fmt.Fprintf(os.Stderr, "Error: requested height %d is less than or equal to current base height %d\n", height, base)
+		os.Exit(1)
+	}
+
+	if height > currentHeight {
+		fmt.Fprintf(os.Stderr, "Error: requested height %d is greater than current height %d\n", height, currentHeight)
+		os.Exit(1)
+	}
+
+	// Create a Pruner instance
+	var pruner *state.Pruner
+	if pruneIndexers {
+		pruner = state.NewPruner(
+			stateStore,
+			blockStore,
+			blockIndexer,
+			txIndexer,
+			logger,
+			state.WithIndexerPruning(true),
+		)
+	} else {
+		pruner = state.NewPruner(
+			stateStore,
+			blockStore,
+			nil,
+			nil,
+			logger,
+		)
+	}
+
+	// Get current application retain height
+	currentRetainHeight, err := pruner.GetApplicationRetainHeight()
+	if err != nil {
+		logger.Info("No existing application retain height found", "err", err)
+		currentRetainHeight = 0
+	}
+	logger.Info("Current application retain height", "height", currentRetainHeight)
+
+	// Set the application retain height to the requested height
+	logger.Info("Setting application retain height", "height", height)
+	if err := pruner.SetApplicationBlockRetainHeight(height); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to set application retain height: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Load current state
+	logger.Info("Loading current state")
+	st, err := stateStore.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to load state: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Perform pruning using the blockStore directly
+	// (pruneBlocksToRetainHeight is private, so we call the underlying method)
+	logger.Info("Starting block pruning", "pruneToHeight", height)
+	pruned, evidenceRetainHeight, err := blockStore.PruneBlocks(height, st)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to prune blocks: %v\n", err)
+		os.Exit(1)
+	}
+
+	logger.Info("Block pruning completed",
+		"pruned", pruned,
+		"evidenceRetainHeight", evidenceRetainHeight,
+	)
+
+	// Prune states
+	if pruned > 0 {
+		logger.Info("Pruning states", "from", base, "to", height, "evidenceRetainHeight", evidenceRetainHeight)
+		prunedStates, err := stateStore.PruneStates(base, height, evidenceRetainHeight)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to prune states: %v\n", err)
+			os.Exit(1)
+		}
+		logger.Info("State pruning completed", "prunedStates", prunedStates)
+		err = blockStoreDB.Compact(nil, nil)
+		if err != nil {
+			logger.Error("Error compacting the pruned blockstore")
+		}
+		err = stateDB.Compact(nil, nil)
+		if err != nil {
+			logger.Error("Error compacting the pruned statestore")
+		}
+	}
+
+	// Get new base height
+	newBase := blockStore.Base()
+	logger.Info("Pruning successful",
+		"blocksRemoved", pruned,
+		"oldBase", base,
+		"newBase", newBase,
+		"currentHeight", currentHeight,
+	)
+
+	// Prune indexers if requested
+	var txIndexerPruned, blockIndexerPruned int64
+
+	if pruneIndexers {
+		// Set tx indexer retain height
+		logger.Info("Setting tx indexer retain height", "height", height)
+		if err := pruner.SetTxIndexerRetainHeight(height); err != nil {
+			logger.Error("Failed to set tx indexer retain height", "err", err)
+		} else {
+			// Prune tx indexer
+			logger.Info("Pruning tx indexer", "targetHeight", height)
+			currentTxRetainHeight, err := pruner.GetTxIndexerRetainHeight()
+			if err != nil {
+				logger.Error("Failed to get tx indexer retain height", "err", err)
+			} else {
+				txIndexerPruned, _, err = txIndexer.Prune(currentTxRetainHeight)
+				if err != nil {
+					logger.Error("Failed to prune tx indexer", "err", err)
+				} else {
+					logger.Info("Tx indexer pruning completed", "pruned", txIndexerPruned)
+					err = txIndexDB.Compact(nil, nil)
+					if err != nil {
+						logger.Error("Compaction of tx indexer failed")
+					}
+				}
+			}
+		}
+
+		// Set block indexer retain height
+		logger.Info("Setting block indexer retain height", "height", height)
+		if err := pruner.SetBlockIndexerRetainHeight(height); err != nil {
+			logger.Error("Failed to set block indexer retain height", "err", err)
+		} else {
+			// Prune block indexer
+			logger.Info("Pruning block indexer", "targetHeight", height)
+			currentBlockRetainHeight, err := pruner.GetBlockIndexerRetainHeight()
+			if err != nil {
+				logger.Error("Failed to get block indexer retain height", "err", err)
+			} else {
+				blockIndexerPruned, _, err = blockIndexer.Prune(currentBlockRetainHeight)
+				if err != nil {
+					logger.Error("Failed to prune block indexer", "err", err)
+				} else {
+					logger.Info("Block indexer pruning completed", "pruned", blockIndexerPruned)
+					err = txIndexDB.Compact(nil, nil)
+					if err != nil {
+						logger.Error("Compaction of block indexer failed")
+					}
+				}
+			}
+		}
+	}
+
+	fmt.Printf("\n✓ Successfully pruned data:\n")
+	fmt.Printf("  Blocks pruned: %d\n", pruned)
+	if pruneIndexers {
+		fmt.Printf("  Tx index entries pruned: %d\n", txIndexerPruned)
+		fmt.Printf("  Block index entries pruned: %d\n", blockIndexerPruned)
+	}
+	fmt.Printf("  Old base height: %d\n", base)
+	fmt.Printf("  New base height: %d\n", newBase)
+	fmt.Printf("  Current height: %d\n", currentHeight)
+	fmt.Printf("  Evidence retain height: %d\n", evidenceRetainHeight)
+	fmt.Printf("  Application retain height set to: %d\n", height)
+}

--- a/scripts/prune-blocks.sh
+++ b/scripts/prune-blocks.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+# Script to prune CometBFT block store up to a specified height
+# Usage: ./prune-blocks.sh <height> [--prune-indexers] [data-dir] [db-backend]
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <height> [--prune-indexers] [data-dir] [db-backend]"
+    echo ""
+    echo "Arguments:"
+    echo "  height            - Height to prune up to (not including this height)"
+    echo "  --prune-indexers  - Optional flag to also prune tx and block indexers"
+    echo "  data-dir          - Path to the data directory (default: \$HOME/.cometbft/data)"
+    echo "  db-backend        - Database backend type (default: goleveldb)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 1000"
+    echo "  $0 1000 --prune-indexers"
+    echo "  $0 1000 --prune-indexers /path/to/data goleveldb"
+    echo "  $0 1000 /path/to/data goleveldb"
+    exit 1
+fi
+
+HEIGHT=$1
+shift
+
+# Check for --prune-indexers flag
+PRUNE_INDEXERS=""
+if [ "$1" = "--prune-indexers" ]; then
+    PRUNE_INDEXERS="-prune-indexers"
+    shift
+fi
+
+DATA_DIR=${1:-""}
+DB_BACKEND=${2:-"goleveldb"}
+
+# Get the script directory and project root
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PROJECT_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
+PRUNE_TOOL_DIR="$PROJECT_ROOT/cmd/prune-blocks"
+
+echo "==> Building prune-blocks tool..."
+cd "$PRUNE_TOOL_DIR"
+go build -o prune-blocks main.go
+
+echo "==> Running prune-blocks tool..."
+if [ -z "$DATA_DIR" ]; then
+    ./prune-blocks -height "$HEIGHT" -db-backend "$DB_BACKEND" $PRUNE_INDEXERS
+else
+    ./prune-blocks -height "$HEIGHT" -data-dir "$DATA_DIR" -db-backend "$DB_BACKEND" $PRUNE_INDEXERS
+fi
+
+echo "==> Pruning completed successfully!"


### PR DESCRIPTION
The provided script will prune the databases of a Comet node (and compact them) when the node is offline. 
It takes as parameters the desired retainhegiht, whether to prune the indexers, the path to the data directory and db backend. 



<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

