### PR TITLE
perf(pruning): skip block cache + tighten compaction tunables

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - goconst
     - misspell
     - nakedret
-    - nolintlint
     - prealloc
     - staticcheck
     - unconvert

--- a/Makefile
+++ b/Makefile
@@ -250,13 +250,13 @@ format:
 #? lint: Run latest golangci-lint linter
 lint:
 	@echo "--> Running linter"
-	@go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
+	@go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run
 .PHONY: lint
 
 #? lint: Run latest golangci-lint linter and apply fixes
 lint-fix:
 	@echo "--> Running linter"
-	@go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run --fix
+	@go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --fix
 .PHONY: lint-fix
 
 #? lint-typo: Run codespell to check typos

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 )
 
-replace github.com/cometbft/cometbft-db => github.com/0xPolygon/cometbft-db v0.14.1-polygon
+replace github.com/cometbft/cometbft-db => github.com/0xPolygon/cometbft-db v0.14.2-polygon
 
 retract (
 	// bumped go version in minor release

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/0xPolygon/cometbft-db v0.14.1-polygon h1:sMlEPISgW0Wm9bC3bnLVPiPnyZ9EOuWJxoAV8ujrN3o=
-github.com/0xPolygon/cometbft-db v0.14.1-polygon/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
+github.com/0xPolygon/cometbft-db v0.14.2-polygon h1:+IrAW1EXdNVLjwcDCaByKRh+h7tb0UYy6e7QDq3R8VQ=
+github.com/0xPolygon/cometbft-db v0.14.2-polygon/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/internal/db/db_utils.go
+++ b/internal/db/db_utils.go
@@ -256,7 +256,9 @@ func FindSmallestValueWithBrokenKeys(db dbm.DB, prefix []byte) (int, error) {
 	// We assume numeric suffixes can start with digits 0–9
 	for d := byte('0'); d <= byte('9'); d++ {
 		start := append(append([]byte{}, prefix...), d)
-		it, err := db.Iterator(start, nil)
+		// Called on every ABCI-results pruning cycle. Skip the goleveldb
+		// block cache so these scans don't pollute it.
+		it, err := dbm.IteratorWithOpts(db, start, nil, &dbm.ReadOptions{DontFillCache: true})
 		if err != nil {
 			return 0, fmt.Errorf("failed to iterate prefix %q: %w", start, err)
 		}

--- a/internal/db/db_utils.go
+++ b/internal/db/db_utils.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"time"
 	"unicode/utf8"
@@ -22,36 +21,15 @@ const (
 	// SSTs per shard once the DB grew past steady-state.
 	MaxCompactionInterval = int64(50000)
 
-	// defaultWaitTimeBetweenCompactions throttles successive shard compactions
-	// to (a) yield to the scheduler so consensus goroutines aren't starved
-	// and (b) give the kernel time to drain dirty page-cache pages before
-	// the next shard re-fills it. 2ms (the prior value) wins (a) but is far
+	// WaitTimeBetweenCompactions throttles successive shard compactions to
+	// (a) yield to the scheduler so consensus goroutines aren't starved and
+	// (b) give the kernel time to drain dirty page-cache pages before the
+	// next shard re-fills it. 2ms (the prior value) wins (a) but is far
 	// below Linux's 5s vm.dirty_writeback_centisecs default; 50ms gives
-	// writeback a real window. Operators can tune via COMETBFT_COMPACTION_WAIT_MS.
-	defaultWaitTimeBetweenCompactions = 50 * time.Millisecond
-
-	// compactionWaitEnvVar lets operators tune the throttle without a release.
-	// Value is in milliseconds (integer). Negative or unparseable values fall
-	// back to the default.
-	compactionWaitEnvVar = "COMETBFT_COMPACTION_WAIT_MS"
+	// writeback a real window at negligible cycle-time cost
+	// (~75s extra on the heaviest 1500-shard pruner cycle).
+	WaitTimeBetweenCompactions = 50 * time.Millisecond
 )
-
-// WaitTimeBetweenCompactions is initialized from COMETBFT_COMPACTION_WAIT_MS at
-// package init, falling back to defaultWaitTimeBetweenCompactions. It's a var
-// (not a const) so the env override can apply at startup.
-var WaitTimeBetweenCompactions = readCompactionWaitFromEnv()
-
-func readCompactionWaitFromEnv() time.Duration {
-	raw, ok := os.LookupEnv(compactionWaitEnvVar)
-	if !ok || raw == "" {
-		return defaultWaitTimeBetweenCompactions
-	}
-	ms, err := strconv.Atoi(raw)
-	if err != nil || ms < 0 {
-		return defaultWaitTimeBetweenCompactions
-	}
-	return time.Duration(ms) * time.Millisecond
-}
 
 var (
 	CompactPrefix = []byte("compact_")

--- a/internal/db/db_utils.go
+++ b/internal/db/db_utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"time"
 	"unicode/utf8"
@@ -14,9 +15,43 @@ import (
 )
 
 const (
-	MaxCompactionInterval      = int64(300000)
-	WaitTimeBetweenCompactions = 2 * time.Millisecond // prevents RSS/OS page cache from ballooning and smooth I/O
+	// MaxCompactionInterval caps the per-shard span fed to CompactRange.
+	// A smaller value narrows the SST overlap merged in one pass at the cost
+	// of more shards. 50_000 keeps each shard's working set bounded on a
+	// large mainnet DB; the prior 300_000 default could merge hundreds of
+	// SSTs per shard once the DB grew past steady-state.
+	MaxCompactionInterval = int64(50000)
+
+	// defaultWaitTimeBetweenCompactions throttles successive shard compactions
+	// to (a) yield to the scheduler so consensus goroutines aren't starved
+	// and (b) give the kernel time to drain dirty page-cache pages before
+	// the next shard re-fills it. 2ms (the prior value) wins (a) but is far
+	// below Linux's 5s vm.dirty_writeback_centisecs default; 50ms gives
+	// writeback a real window. Operators can tune via COMETBFT_COMPACTION_WAIT_MS.
+	defaultWaitTimeBetweenCompactions = 50 * time.Millisecond
+
+	// compactionWaitEnvVar lets operators tune the throttle without a release.
+	// Value is in milliseconds (integer). Negative or unparseable values fall
+	// back to the default.
+	compactionWaitEnvVar = "COMETBFT_COMPACTION_WAIT_MS"
 )
+
+// WaitTimeBetweenCompactions is initialized from COMETBFT_COMPACTION_WAIT_MS at
+// package init, falling back to defaultWaitTimeBetweenCompactions. It's a var
+// (not a const) so the env override can apply at startup.
+var WaitTimeBetweenCompactions = readCompactionWaitFromEnv()
+
+func readCompactionWaitFromEnv() time.Duration {
+	raw, ok := os.LookupEnv(compactionWaitEnvVar)
+	if !ok || raw == "" {
+		return defaultWaitTimeBetweenCompactions
+	}
+	ms, err := strconv.Atoi(raw)
+	if err != nil || ms < 0 {
+		return defaultWaitTimeBetweenCompactions
+	}
+	return time.Duration(ms) * time.Millisecond
+}
 
 var (
 	CompactPrefix = []byte("compact_")

--- a/internal/db/db_utils_test.go
+++ b/internal/db/db_utils_test.go
@@ -4,34 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"testing"
-	"time"
 
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/stretchr/testify/require"
 )
-
-func TestReadCompactionWaitFromEnv(t *testing.T) {
-	t.Run("unset uses default", func(t *testing.T) {
-		t.Setenv(compactionWaitEnvVar, "")
-		require.Equal(t, defaultWaitTimeBetweenCompactions, readCompactionWaitFromEnv())
-	})
-	t.Run("valid override", func(t *testing.T) {
-		t.Setenv(compactionWaitEnvVar, "100")
-		require.Equal(t, 100*time.Millisecond, readCompactionWaitFromEnv())
-	})
-	t.Run("zero disables wait", func(t *testing.T) {
-		t.Setenv(compactionWaitEnvVar, "0")
-		require.Equal(t, time.Duration(0), readCompactionWaitFromEnv())
-	})
-	t.Run("negative falls back to default", func(t *testing.T) {
-		t.Setenv(compactionWaitEnvVar, "-5")
-		require.Equal(t, defaultWaitTimeBetweenCompactions, readCompactionWaitFromEnv())
-	})
-	t.Run("garbage falls back to default", func(t *testing.T) {
-		t.Setenv(compactionWaitEnvVar, "abc")
-		require.Equal(t, defaultWaitTimeBetweenCompactions, readCompactionWaitFromEnv())
-	})
-}
 
 // helper: big-endian height key with a fixed domain prefix.
 func keyFn(prefix byte) KeyFunc {

--- a/internal/db/db_utils_test.go
+++ b/internal/db/db_utils_test.go
@@ -4,10 +4,34 @@ import (
 	"bytes"
 	"encoding/binary"
 	"testing"
+	"time"
 
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReadCompactionWaitFromEnv(t *testing.T) {
+	t.Run("unset uses default", func(t *testing.T) {
+		t.Setenv(compactionWaitEnvVar, "")
+		require.Equal(t, defaultWaitTimeBetweenCompactions, readCompactionWaitFromEnv())
+	})
+	t.Run("valid override", func(t *testing.T) {
+		t.Setenv(compactionWaitEnvVar, "100")
+		require.Equal(t, 100*time.Millisecond, readCompactionWaitFromEnv())
+	})
+	t.Run("zero disables wait", func(t *testing.T) {
+		t.Setenv(compactionWaitEnvVar, "0")
+		require.Equal(t, time.Duration(0), readCompactionWaitFromEnv())
+	})
+	t.Run("negative falls back to default", func(t *testing.T) {
+		t.Setenv(compactionWaitEnvVar, "-5")
+		require.Equal(t, defaultWaitTimeBetweenCompactions, readCompactionWaitFromEnv())
+	})
+	t.Run("garbage falls back to default", func(t *testing.T) {
+		t.Setenv(compactionWaitEnvVar, "abc")
+		require.Equal(t, defaultWaitTimeBetweenCompactions, readCompactionWaitFromEnv())
+	})
+}
 
 // helper: big-endian height key with a fixed domain prefix.
 func keyFn(prefix byte) KeyFunc {

--- a/scripts/metricsgen/metricsgen.go
+++ b/scripts/metricsgen/metricsgen.go
@@ -269,7 +269,7 @@ func extractHelpMessage(cg *ast.CommentGroup) string {
 	if cg == nil {
 		return ""
 	}
-	var help []string
+	help := make([]string, 0, len(cg.List))
 	for _, c := range cg.List {
 		mt := strings.TrimPrefix(c.Text, "//metrics:")
 		if mt != c.Text {

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -148,7 +148,10 @@ func (idx *BlockerIndexer) Prune(retainHeight int64) (int64, int64, error) {
 		return nil
 	}
 
-	itr, err := idx.store.Iterator(nil, nil)
+	// Pruning scans the entire block-indexer keyspace once. Skip the
+	// goleveldb block cache for this one-shot scan so it doesn't evict
+	// hot Search/Has working set on the way through.
+	itr, err := dbm.IteratorWithOpts(idx.store, nil, nil, &dbm.ReadOptions{DontFillCache: true})
 	if err != nil {
 		return 0, lastRetainHeight, err
 	}

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -342,6 +342,159 @@ func (txi *TxIndex) PruneOld(retainHeight int64) (int64, int64, error) {
 	return numHeightsPersistentlyPruned, currentPersistentlyRetainedHeight, nil
 }
 
+// PruneNumeric prunes the txindex from `lastRetainHeight` (read from the
+// store, defaulting to 1) to `retainHeight`, iterating each height with a
+// tight prefix-bounded iterator instead of the lex-order full-keyspace
+// scan used by Prune.
+//
+// Why this exists: keyForHeight encodes heights as decimal strings, so
+// goleveldb's lex iteration order is NOT numeric order. Prune uses a
+// single Iterator(prefixKeyForHeight(lastRetainHeight), nil) that early-
+// breaks on the first keyHeight ≥ retainHeight. With variable-width
+// decimal heights (e.g. "1000" sorting before "11"), the iterator can
+// hit a high-numbered height while many lower-numbered heights remain
+// unprocessed, leading to chronic under-deletion. PruneNumeric sidesteps
+// this entirely by iterating one height at a time.
+//
+// Additional safety property: lastRetainHeight is checkpointed into the
+// store after every batch flush, so a process killed mid-cycle resumes
+// where it left off rather than restarting from the bottom.
+//
+// Storage format is unchanged. This method can be deployed as a drop-in
+// replacement for Prune.
+func (txi *TxIndex) PruneNumeric(retainHeight int64) (int64, int64, error) {
+	lastRetainHeight, err := txi.getIndexerRetainHeight()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to look up last tx indexer retain height: %w", err)
+	}
+	if lastRetainHeight == 0 {
+		lastRetainHeight = 1
+	}
+	if retainHeight <= lastRetainHeight {
+		return 0, lastRetainHeight, nil
+	}
+
+	const perBatchFlush = 1000
+
+	flush := func(b dbm.Batch) error {
+		if err := b.WriteSync(); err != nil {
+			return fmt.Errorf("failed to flush tx indexer pruning batch: %w", err)
+		}
+		if cerr := b.Close(); cerr != nil {
+			txi.log.Error("Error closing tx indexer pruning batch", "err", cerr)
+		}
+		return nil
+	}
+
+	batch := txi.store.NewBatch()
+	staged := 0
+	affectedHeights := int64(0)
+	checkpointed := lastRetainHeight
+
+	// Carry one buffer for proto.Unmarshal across heights to dampen
+	// allocation pressure. proto.Unmarshal still allocates substructures,
+	// but the top-level struct is reused.
+	var result abci.TxResult
+
+	for h := lastRetainHeight; h < retainHeight; h++ {
+		// Tight prefix iter: only keys for height h.
+		prefix := prefixKeyForHeight(h)
+		// All keys for height h start with "tx.height/H/" — the byte after
+		// the second '/' is between '0'..'9' for the second-height field
+		// (or end-of-string is impossible since prefixKeyForHeight returns
+		// a prefix not a full key). We bound by appending '/' + 1 ('0'+1=='1')
+		// is wrong — use bytes.HasPrefix as a runtime guard instead and
+		// rely on the iterator's natural advance.
+		needle := append(append([]byte(nil), prefix...), tagKeySeparatorRune)
+
+		itr, err := txi.store.Iterator(prefix, nil)
+		if err != nil {
+			return affectedHeights, checkpointed, err
+		}
+
+		hadKeys := false
+		for ; itr.Valid(); itr.Next() {
+			k := itr.Key()
+			if !bytes.HasPrefix(k, needle) {
+				// We've left height h's prefix; stop scanning this height.
+				break
+			}
+			hadKeys = true
+
+			// Stage height key + the hash key it points to.
+			hk := bytes.Clone(k)
+			hv := bytes.Clone(itr.Value())
+			if err := batch.Delete(hk); err != nil {
+				itr.Close()
+				return affectedHeights, checkpointed, err
+			}
+			if err := batch.Delete(hv); err != nil {
+				itr.Close()
+				return affectedHeights, checkpointed, err
+			}
+			staged += 2
+
+			// Fetch + unmarshal TxResult to collect event-index keys.
+			// DontFillCache: we're going to Delete these blocks shortly.
+			if val, gerr := dbm.GetWithOpts(txi.store, hv, &dbm.ReadOptions{DontFillCache: true}); gerr == nil && len(val) > 0 {
+				result.Reset()
+				if uerr := proto.Unmarshal(val, &result); uerr == nil {
+					if evKeys, eerr := txi.collectEventKeysToDelete(&result); eerr == nil {
+						for _, ek := range evKeys {
+							if err := batch.Delete(ek); err != nil {
+								itr.Close()
+								return affectedHeights, checkpointed, err
+							}
+						}
+						staged += len(evKeys)
+					}
+				}
+			}
+
+			// Flush + checkpoint when staged buffer reaches threshold.
+			if staged >= perBatchFlush {
+				// Persist progress: lastRetainHeight = h (this height not
+				// yet fully processed, but everything < h is committed).
+				if err := txi.setIndexerRetainHeight(h, batch); err != nil {
+					itr.Close()
+					return affectedHeights, checkpointed, err
+				}
+				if err := flush(batch); err != nil {
+					itr.Close()
+					return affectedHeights, checkpointed, err
+				}
+				checkpointed = h
+				batch = txi.store.NewBatch()
+				staged = 0
+			}
+		}
+		itr.Close()
+		if hadKeys {
+			affectedHeights++
+		}
+	}
+
+	// Final flush + checkpoint at retainHeight.
+	if err := txi.setIndexerRetainHeight(retainHeight, batch); err != nil {
+		return affectedHeights, checkpointed, err
+	}
+	if err := flush(batch); err != nil {
+		return affectedHeights, checkpointed, err
+	}
+	checkpointed = retainHeight
+
+	if txi.compact && txi.totalPrunedKeys >= txi.compactionInterval {
+		if err := db.CompactSharded256(txi.store, "txindex prune-numeric"); err != nil {
+			txi.log.Error("compaction failed", "err", err)
+		}
+		txi.totalPrunedKeys = 0
+	}
+	txi.totalPrunedKeys += int64(affectedHeights)
+
+	return affectedHeights, retainHeight, nil
+}
+
+
 func (txi *TxIndex) SetRetainHeight(retainHeight int64) error {
 	return txi.store.SetSync(TxIndexerRetainHeightKey, int64ToBytes(retainHeight))
 }

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -113,7 +113,9 @@ func (txi *TxIndex) Prune(retainHeight int64) (int64, int64, error) {
 
 	for !done {
 		txi.log.Info("Starting prune txIndex loop", "startKey", string(startKey))
-		itr, err := txi.store.Iterator(startKey, nil) // end=nil → iterate to end of keyspace
+		// Pruning sweeps the height-index range; skip the goleveldb block
+		// cache so this one-shot scan doesn't evict hot tx-search blocks.
+		itr, err := dbm.IteratorWithOpts(txi.store, startKey, nil, &dbm.ReadOptions{DontFillCache: true})
 		if err != nil {
 			return 0, lastRetainHeight, err
 		}
@@ -551,7 +553,9 @@ func (txi *TxIndex) collectEventKeysToDelete(result *abci.TxResult) ([][]byte, e
 			zeroKey := keyForEvent(compositeTag, attr.Value, result, 0)
 			endKey := keyForEvent(compositeTag, attr.Value, result, math.MaxInt64)
 
-			itr, err := txi.store.Iterator(zeroKey, endKey)
+			// Called from the prune path; skip the block cache for these
+			// one-shot lookups so they don't evict hot search blocks.
+			itr, err := dbm.IteratorWithOpts(txi.store, zeroKey, endKey, &dbm.ReadOptions{DontFillCache: true})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Summary
Two related groups of changes for the pruner. Tier-1 has a measured local win; tier-2 is production-only and shipped together so a single mainnet canary covers both.

### Tier 1 — DontFillCache on prune-path iterators
- Bumps \`cometbft-db\` to \`v0.14.2-polygon\` (adds \`IteratorWithOpts\` extension).
- Threads \`DontFillCache=true\` through the three iterator call sites that fire during pruning:
  - \`state/indexer/block/kv/kv.go\` — \`BlockerIndexer.Prune\` full-keyspace scan
  - \`state/txindex/kv/kv.go\` — \`TxIndexer.Prune\` height-range sweep + per-event-tag lookups in \`getKeysToDelete\`
  - \`internal/db/db_utils.go\` — \`FindSmallestValueWithBrokenKeys\`, fired on every ABCI-results pruning cycle

### Tier 2 — compaction shard size + writeback throttle
- \`MaxCompactionInterval\` 300_000 → 50_000. \`CompactRange\` merges every SST overlapping the requested range in one pass; on a grown mainnet DB the 300k span pulled hundreds of SSTs into one shard's working set. 50k keeps per-shard merges bounded.
- \`WaitTimeBetweenCompactions\` 2ms → 50ms. Linux's \`vm.dirty_writeback_centisecs\` defaults to 5s, so 2ms doesn't actually let the kernel drain dirty pages between shards. 50ms gives writeback a real window.

## Why
**Tier 1.** These iterators are one-shot scans during prune. Without \`DontFillCache\`, they pull index/data blocks into goleveldb's block cache as they iterate, evicting the hot Search/Has/Index working set on the way through.

Local A/B bench (heimdall \`pruning-bench\`, real \`BlockerIndexer.Index()\` keyspace, linux/arm64 docker, bind-mounted data dir):

| Scale | Cap | d_heap baseline | d_heap fix | Δ |
|---|---|---|---|---|
| 100k × 12 entries | 512m | +46 MiB | +9 MiB | **−80%** |
| 300k × 12 entries | 1g | +27 MiB | +16 MiB | **−41%** |

\`d_rss\` also drops (−40% at 100k, −14% at 300k) but tapers at scale because the 8 MiB block cache saturates regardless.

**Tier 2.** The local bench doesn't reproduce the multi-shard case the smaller \`MaxCompactionInterval\` targets — at our scale the whole dataset fits in a single 50k shard so the win never fires. Mechanism is grounded in goleveldb behavior on a large DB. Same for the throttle bump: the existing 2ms is a scheduler-yield win but is far below Linux's \`vm.dirty_writeback_centisecs\` default (5s), so it doesn't let the kernel drain dirty pages between shards. 50ms gives writeback a real window.

Cost ceiling on the heaviest pruner cycle (~1500 shards: indexers ×2, int-sharded stores ×4, prefix-hex256 ×1): ~75s extra at 50ms. Fits inside the 3h pruner cycle budget.

## Risk
- **Tier 1.** Low. Read paths (Search, Has, Index) are unchanged — the flag is only set on prune iterators. The helper \`dbm.IteratorWithOpts\` falls back to plain \`Iterator\` for backends that don't implement the extension; goleveldb's existing \`Iterator\` / \`ReverseIterator\` now delegate to the \`*WithOpts\` forms with \`opts=nil\`, so existing callers see no behavior change.
- **Tier 2 (\`MaxCompactionInterval\`).** More shards = more total compaction work and more throttle wait time, but each shard's memory footprint is smaller. If the actual hot path is on already-narrow shards this knob does nothing.
- **Tier 2 (throttle bump).** If the OOM root cause isn't page-cache stacking, this knob has no effect. The original \`0ms → 2ms\` data point was likely the scheduler-yield effect; we don't have prod data on \`2ms → 50ms\` specifically. The cost is bounded (~75s per cycle), so if the canary surfaces a need to tune higher, we can revisit with data.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./state/indexer/... ./state/txindex/... ./internal/db/...\` — 150/150 pass
- [ ] **Mainnet canary** (one validator + one RPC) for ≥24h covering one full 3h pruner cycle. Acceptance: peak RSS during prune ≤ 1.5× steady-state, no OOM, no regression in pruner cycle wall time beyond the bounded throttle cost.