### PR TITLE
feat(consensus): report catching_up when fallen behind peers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1030,6 +1030,25 @@ type ConsensusConfig struct {
 
 	// BlockTimeTolerance is the maximum allowed difference between the proposed block time and wall-clock time.
 	BlockTimeTolerance time.Duration `mapstructure:"block_time_tolerance"`
+
+	// CatchupLagThreshold is how many blocks a peer may be ahead of us before we
+	// report catching_up=true. The reactor's WaitSync latch only reflects the
+	// initial block-sync at startup and stays false for the rest of the process, so
+	// without this check a node that later stops keeping up with its peers still
+	// reports catching_up=false. The comparison is against peer-reported heights
+	// rather than block-time staleness, so a network where every node has
+	// legitimately stopped at the same height is not misreported as catching up.
+	// 0 disables the check; must be >=2 when enabled to absorb the normal one-height
+	// round skew between synced peers.
+	CatchupLagThreshold int64 `mapstructure:"catchup_lag_threshold"`
+	// MinExpectedPeers, when >0, reports catching_up=true while connected peers are
+	// below this count, since a node that cannot reach enough peers cannot establish
+	// that it is current. 0 keeps single-node deployments healthy.
+	MinExpectedPeers int `mapstructure:"min_expected_peers"`
+	// CatchupDebounceDuration is how long the peer-lag condition must hold
+	// continuously before catching_up flips to true, damping flapping at the
+	// threshold boundary. The transition back to false is immediate.
+	CatchupDebounceDuration time.Duration `mapstructure:"catchup_debounce_duration"`
 }
 
 // DefaultConsensusConfig returns a default configuration for the consensus service
@@ -1050,6 +1069,9 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		PeerQueryMaj23SleepDuration: 2000 * time.Millisecond,
 		DoubleSignCheckHeight:       int64(0),
 		BlockTimeTolerance:          60 * time.Second,
+		CatchupLagThreshold:         5,
+		MinExpectedPeers:            0,
+		CatchupDebounceDuration:     10 * time.Second,
 	}
 }
 
@@ -1154,6 +1176,18 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 	}
 	if cfg.BlockTimeTolerance <= 0 {
 		return errors.New("block_time_tolerance must be positive")
+	}
+	if cfg.CatchupLagThreshold < 0 {
+		return errors.New("catchup_lag_threshold can't be negative")
+	}
+	if cfg.CatchupLagThreshold == 1 {
+		return errors.New("catchup_lag_threshold must be 0 (disabled) or >=2 to absorb round skew")
+	}
+	if cfg.MinExpectedPeers < 0 {
+		return errors.New("min_expected_peers can't be negative")
+	}
+	if cfg.CatchupDebounceDuration < 0 {
+		return errors.New("catchup_debounce_duration can't be negative")
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1038,13 +1038,11 @@ type ConsensusConfig struct {
 	// reports catching_up=false. The comparison is against peer-reported heights
 	// rather than block-time staleness, so a network where every node has
 	// legitimately stopped at the same height is not misreported as catching up.
-	// 0 disables the check; must be >=2 when enabled to absorb the normal one-height
-	// round skew between synced peers.
+	// 0 disables peer-height lag detection only; must be >=2 when enabled to absorb
+	// the normal one-height round skew between synced peers. The separate zero-peer
+	// rule (a node with no peers in a multi-validator network reports catching_up)
+	// always applies, independent of this threshold.
 	CatchupLagThreshold int64 `mapstructure:"catchup_lag_threshold"`
-	// MinExpectedPeers, when >0, reports catching_up=true while connected peers are
-	// below this count, since a node that cannot reach enough peers cannot establish
-	// that it is current. 0 keeps single-node deployments healthy.
-	MinExpectedPeers int `mapstructure:"min_expected_peers"`
 	// CatchupDebounceDuration is how long the peer-lag condition must hold
 	// continuously before catching_up flips to true, damping flapping at the
 	// threshold boundary. The transition back to false is immediate.
@@ -1070,7 +1068,6 @@ func DefaultConsensusConfig() *ConsensusConfig {
 		DoubleSignCheckHeight:       int64(0),
 		BlockTimeTolerance:          60 * time.Second,
 		CatchupLagThreshold:         5,
-		MinExpectedPeers:            0,
 		CatchupDebounceDuration:     10 * time.Second,
 	}
 }
@@ -1182,9 +1179,6 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 	}
 	if cfg.CatchupLagThreshold == 1 {
 		return errors.New("catchup_lag_threshold must be 0 (disabled) or >=2 to absorb round skew")
-	}
-	if cfg.MinExpectedPeers < 0 {
-		return errors.New("min_expected_peers can't be negative")
 	}
 	if cfg.CatchupDebounceDuration < 0 {
 		return errors.New("catchup_debounce_duration can't be negative")

--- a/config/config.go
+++ b/config/config.go
@@ -1181,7 +1181,7 @@ func (cfg *ConsensusConfig) ValidateBasic() error {
 		return errors.New("catchup_lag_threshold can't be negative")
 	}
 	if cfg.CatchupLagThreshold == 1 {
-		return errors.New("catchup_lag_threshold must be 0 (disabled) or >=2 to absorb round skew")
+		return errors.New("catchup_lag_threshold must be 0 (disabled) or >=2 (margin beyond the one-height round skew)")
 	}
 	if cfg.CatchupDebounceDuration < 0 {
 		return errors.New("catchup_debounce_duration can't be negative")

--- a/config/config.go
+++ b/config/config.go
@@ -1031,16 +1031,19 @@ type ConsensusConfig struct {
 	// BlockTimeTolerance is the maximum allowed difference between the proposed block time and wall-clock time.
 	BlockTimeTolerance time.Duration `mapstructure:"block_time_tolerance"`
 
-	// CatchupLagThreshold is how many blocks a peer may be ahead of us before we
-	// report catching_up=true. The reactor's WaitSync latch only reflects the
-	// initial block-sync at startup and stays false for the rest of the process, so
-	// without this check a node that later stops keeping up with its peers still
-	// reports catching_up=false. The comparison is against peer-reported heights
-	// rather than block-time staleness, so a network where every node has
-	// legitimately stopped at the same height is not misreported as catching up.
+	// CatchupLagThreshold is how many blocks ahead of us a peer must be to count as
+	// reporting us behind; catching_up=true requires a majority of connected peers to
+	// be that far ahead. The reactor's WaitSync latch only reflects the initial
+	// block-sync at startup and stays false for the rest of the process, so without
+	// this check a node that later stops keeping up with its peers still reports
+	// catching_up=false. The comparison is against peer-reported heights rather than
+	// block-time staleness, so a network where every node has legitimately stopped at
+	// the same height is not misreported as catching up; peer heights are unverified
+	// gossip, so the lag must be corroborated by a majority of at least two connected
+	// peers, which keeps a single peer from driving the signal.
 	// 0 disables peer-height lag detection only; must be >=2 when enabled to absorb
 	// the normal one-height round skew between synced peers. The separate zero-peer
-	// rule (a node with no peers in a multi-validator network reports catching_up)
+	// rule (a node with no peers that is not the sole validator reports catching_up)
 	// always applies, independent of this threshold.
 	CatchupLagThreshold int64 `mapstructure:"catchup_lag_threshold"`
 	// CatchupDebounceDuration is how long the peer-lag condition must hold

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -179,6 +179,12 @@ func TestConsensusConfig_ValidateBasic(t *testing.T) {
 		"BlockTimeTolerance":                   {func(c *config.ConsensusConfig) { c.BlockTimeTolerance = time.Second }, false},
 		"BlockTimeTolerance zero":              {func(c *config.ConsensusConfig) { c.BlockTimeTolerance = 0 }, true},
 		"BlockTimeTolerance negative":          {func(c *config.ConsensusConfig) { c.BlockTimeTolerance = -1 }, true},
+		"CatchupLagThreshold disabled":         {func(c *config.ConsensusConfig) { c.CatchupLagThreshold = 0 }, false},
+		"CatchupLagThreshold one":              {func(c *config.ConsensusConfig) { c.CatchupLagThreshold = 1 }, true},
+		"CatchupLagThreshold two":              {func(c *config.ConsensusConfig) { c.CatchupLagThreshold = 2 }, false},
+		"CatchupLagThreshold negative":         {func(c *config.ConsensusConfig) { c.CatchupLagThreshold = -1 }, true},
+		"CatchupDebounceDuration zero":         {func(c *config.ConsensusConfig) { c.CatchupDebounceDuration = 0 }, false},
+		"CatchupDebounceDuration negative":     {func(c *config.ConsensusConfig) { c.CatchupDebounceDuration = -1 }, true},
 	}
 	for desc, tc := range testcases {
 		t.Run(desc, func(t *testing.T) {
@@ -193,6 +199,12 @@ func TestConsensusConfig_ValidateBasic(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultConsensusConfigCatchupDefaults(t *testing.T) {
+	cfg := config.DefaultConsensusConfig()
+	assert.Equal(t, int64(5), cfg.CatchupLagThreshold)
+	assert.Equal(t, 10*time.Second, cfg.CatchupDebounceDuration)
 }
 
 func TestInstrumentationConfigValidateBasic(t *testing.T) {

--- a/config/toml.go
+++ b/config/toml.go
@@ -519,11 +519,11 @@ peer_query_maj23_sleep_duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 # Maximum allowed difference between proposed block time and wall-clock time.
 block_time_tolerance = "{{ .Consensus.BlockTimeTolerance }}"
 
-# After initial block-sync completes, report catching_up=true when a peer is more
-# than this many blocks ahead of us (i.e. this node has stopped keeping up). Set to
-# 0 to disable peer-height lag detection only; must be >=2 when enabled to absorb
-# normal round skew. A node with no peers in a multi-validator network still reports
-# catching_up regardless of this setting.
+# After initial block-sync completes, report catching_up=true when a majority of the
+# connected peers (at least two) are more than this many blocks ahead of us (i.e. this
+# node has stopped keeping up). Set to 0 to disable peer-height lag detection only;
+# must be >=2 when enabled to absorb normal round skew. A node with no peers that is
+# not the sole validator still reports catching_up regardless of this setting.
 catchup_lag_threshold = {{ .Consensus.CatchupLagThreshold }}
 
 # How long the peer-lag condition must hold before catching_up flips to true

--- a/config/toml.go
+++ b/config/toml.go
@@ -521,12 +521,10 @@ block_time_tolerance = "{{ .Consensus.BlockTimeTolerance }}"
 
 # After initial block-sync completes, report catching_up=true when a peer is more
 # than this many blocks ahead of us (i.e. this node has stopped keeping up). Set to
-# 0 to disable; must be >=2 when enabled to absorb normal round skew.
+# 0 to disable peer-height lag detection only; must be >=2 when enabled to absorb
+# normal round skew. A node with no peers in a multi-validator network still reports
+# catching_up regardless of this setting.
 catchup_lag_threshold = {{ .Consensus.CatchupLagThreshold }}
-
-# When >0, report catching_up=true while connected peers are below this count, since
-# the node cannot establish that it is current. Keep at 0 for single-node deployments.
-min_expected_peers = {{ .Consensus.MinExpectedPeers }}
 
 # How long the peer-lag condition must hold before catching_up flips to true
 # (flap damping). The transition back to false is immediate.

--- a/config/toml.go
+++ b/config/toml.go
@@ -519,6 +519,19 @@ peer_query_maj23_sleep_duration = "{{ .Consensus.PeerQueryMaj23SleepDuration }}"
 # Maximum allowed difference between proposed block time and wall-clock time.
 block_time_tolerance = "{{ .Consensus.BlockTimeTolerance }}"
 
+# After initial block-sync completes, report catching_up=true when a peer is more
+# than this many blocks ahead of us (i.e. this node has stopped keeping up). Set to
+# 0 to disable; must be >=2 when enabled to absorb normal round skew.
+catchup_lag_threshold = {{ .Consensus.CatchupLagThreshold }}
+
+# When >0, report catching_up=true while connected peers are below this count, since
+# the node cannot establish that it is current. Keep at 0 for single-node deployments.
+min_expected_peers = {{ .Consensus.MinExpectedPeers }}
+
+# How long the peer-lag condition must hold before catching_up flips to true
+# (flap damping). The transition back to false is immediate.
+catchup_debounce_duration = "{{ .Consensus.CatchupDebounceDuration }}"
+
 #######################################################
 ###         Storage Configuration Options           ###
 #######################################################

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -449,19 +449,10 @@ func (conR *Reactor) IsBehind() bool {
 	return conR.applyDebounceLocked(raw, time.Now())
 }
 
-// isBehindRaw gathers the local and max peer heights and applies the lag decision,
-// without debouncing. It holds no lock while reading peers / round state.
+// isBehindRaw gathers the local height and peer heights and applies the lag
+// decision, without debouncing. It holds no lock while reading peers / round state.
 func (conR *Reactor) isBehindRaw() bool {
-	peers := conR.Switch.Peers().List()
-
-	peerHeights := make([]int64, 0, len(peers))
-	for _, peer := range peers {
-		ps, ok := peer.Get(types.PeerStateKey).(*PeerState)
-		if !ok {
-			continue
-		}
-		peerHeights = append(peerHeights, ps.GetHeight())
-	}
+	peerHeights := collectPeerHeights(conR.Switch.Peers().List())
 
 	// Sole-validator status is read live from consensus state on every call, so it
 	// reflects validator-set changes this node has committed into local round state
@@ -469,6 +460,22 @@ func (conR *Reactor) isBehindRaw() bool {
 	// can't observe the other side's update, but that only makes it report behind,
 	// which is correct.)
 	return conR.evaluateBehind(conR.getRoundState().Height, peerHeights, conR.conS.isLocalSoleValidator())
+}
+
+// collectPeerHeights returns the gossiped consensus height of every peer that
+// carries a consensus PeerState. Peers without one (key absent or wrong type)
+// are skipped rather than counted as height 0, so they don't dilute the
+// majority calculation in evaluateBehind.
+func collectPeerHeights(peers []p2p.Peer) []int64 {
+	heights := make([]int64, 0, len(peers))
+	for _, peer := range peers {
+		ps, ok := peer.Get(types.PeerStateKey).(*PeerState)
+		if !ok {
+			continue
+		}
+		heights = append(heights, ps.GetHeight())
+	}
+	return heights
 }
 
 // minCorroboratingPeers is the fewest connected peers required before peer-height

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -46,6 +46,15 @@ type Reactor struct {
 	eventBus *types.EventBus
 	rs       *cstypes.RoundState
 
+	// catchUpLagThreshold, minExpectedPeers and catchUpDebounce drive IsBehind,
+	// which lets /status report catching_up=true after initial sync when this node
+	// has fallen behind live peers. behindSince tracks how long the lag condition
+	// has held continuously, for debouncing.
+	catchUpLagThreshold int64
+	minExpectedPeers    int
+	catchUpDebounce     time.Duration
+	behindSince         time.Time
+
 	Metrics *Metrics
 }
 
@@ -420,6 +429,70 @@ func (conR *Reactor) WaitSync() bool {
 	conR.mtx.RLock()
 	defer conR.mtx.RUnlock()
 	return conR.waitSync
+}
+
+// IsBehind reports whether this node has stopped keeping up with its peers after
+// the initial block-sync has completed. WaitSync only reflects startup block-sync
+// and stays false for the rest of the process, so on its own catching_up never
+// reflects a node that later falls behind. IsBehind closes that gap from
+// peer-reported heights.
+//
+// It compares heights rather than block-time staleness on purpose: a stale local
+// block time can't distinguish a node that is behind its peers (some peer reports a
+// greater height) from a network where every node has legitimately stopped at the
+// same height (no peer is ahead). Only the former is "catching up"; reporting the
+// latter as catching up would be a false positive.
+func (conR *Reactor) IsBehind() bool {
+	raw := conR.isBehindRaw()
+
+	conR.mtx.Lock()
+	defer conR.mtx.Unlock()
+	return conR.applyDebounceLocked(raw, time.Now())
+}
+
+// isBehindRaw gathers the local and max peer heights and applies the lag decision,
+// without debouncing. It holds no lock while reading peers / round state.
+func (conR *Reactor) isBehindRaw() bool {
+	peers := conR.Switch.Peers().List()
+
+	var maxPeerHeight int64
+	for _, peer := range peers {
+		ps, ok := peer.Get(types.PeerStateKey).(*PeerState)
+		if !ok {
+			continue
+		}
+		if h := ps.GetHeight(); h > maxPeerHeight {
+			maxPeerHeight = h
+		}
+	}
+
+	return conR.evaluateBehind(conR.getRoundState().Height, maxPeerHeight, len(peers))
+}
+
+// evaluateBehind is the pure lag decision. Too few peers means we can't prove we're
+// current (off by default so single-node stays healthy). A zero threshold disables
+// the height check. maxPeerHeight == 0 means no peer height learned yet.
+func (conR *Reactor) evaluateBehind(myHeight, maxPeerHeight int64, nPeers int) bool {
+	if conR.minExpectedPeers > 0 && nPeers < conR.minExpectedPeers {
+		return true
+	}
+	if conR.catchUpLagThreshold <= 0 || maxPeerHeight == 0 {
+		return false
+	}
+	return maxPeerHeight-myHeight > conR.catchUpLagThreshold
+}
+
+// applyDebounceLocked requires the lag condition to hold for catchUpDebounce before
+// returning true; recovery to false is immediate. conR.mtx must be held.
+func (conR *Reactor) applyDebounceLocked(raw bool, now time.Time) bool {
+	if !raw {
+		conR.behindSince = time.Time{}
+		return false
+	}
+	if conR.behindSince.IsZero() {
+		conR.behindSince = now
+	}
+	return now.Sub(conR.behindSince) >= conR.catchUpDebounce
 }
 
 //--------------------------------------
@@ -1055,6 +1128,15 @@ func (conR *Reactor) StringIndented(indent string) string {
 // ReactorMetrics sets the metrics
 func ReactorMetrics(metrics *Metrics) ReactorOption {
 	return func(conR *Reactor) { conR.Metrics = metrics }
+}
+
+// ReactorCatchupConfig configures the IsBehind heuristic that backs catching_up.
+func ReactorCatchupConfig(lagThreshold int64, minPeers int, debounce time.Duration) ReactorOption {
+	return func(conR *Reactor) {
+		conR.catchUpLagThreshold = lagThreshold
+		conR.minExpectedPeers = minPeers
+		conR.catchUpDebounce = debounce
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -46,12 +46,11 @@ type Reactor struct {
 	eventBus *types.EventBus
 	rs       *cstypes.RoundState
 
-	// catchUpLagThreshold, minExpectedPeers and catchUpDebounce drive IsBehind,
-	// which lets /status report catching_up=true after initial sync when this node
-	// has fallen behind live peers. behindSince tracks how long the lag condition
-	// has held continuously, for debouncing.
+	// catchUpLagThreshold and catchUpDebounce drive IsBehind, which lets /status
+	// report catching_up=true after initial sync when this node has fallen behind
+	// live peers. behindSince tracks how long the lag condition has held
+	// continuously, for debouncing.
 	catchUpLagThreshold int64
-	minExpectedPeers    int
 	catchUpDebounce     time.Duration
 	behindSince         time.Time
 
@@ -466,15 +465,22 @@ func (conR *Reactor) isBehindRaw() bool {
 		}
 	}
 
-	return conR.evaluateBehind(conR.getRoundState().Height, maxPeerHeight, len(peers))
+	// Sole-validator status is read live from consensus state on every call, so it
+	// reflects validator-set changes this node has committed into local round state
+	// without any cached value to update. (A node partitioned before a set change
+	// can't observe the other side's update, but that only makes it report behind,
+	// which is correct.)
+	return conR.evaluateBehind(conR.getRoundState().Height, maxPeerHeight, len(peers), conR.conS.isLocalSoleValidator())
 }
 
-// evaluateBehind is the pure lag decision. Too few peers means we can't prove we're
-// current (off by default so single-node stays healthy). A zero threshold disables
-// the height check. maxPeerHeight == 0 means no peer height learned yet.
-func (conR *Reactor) evaluateBehind(myHeight, maxPeerHeight int64, nPeers int) bool {
-	if conR.minExpectedPeers > 0 && nPeers < conR.minExpectedPeers {
-		return true
+// evaluateBehind is the pure lag decision. With no peers we can't observe progress,
+// so we report behind unless this node can finalize on its own (it's the sole
+// validator); a non-validator or a validator in a larger set genuinely needs peers.
+// A zero threshold disables the height-lag check (the zero-peer rule still applies).
+// maxPeerHeight == 0 means no peer height learned yet.
+func (conR *Reactor) evaluateBehind(myHeight, maxPeerHeight int64, nPeers int, isSoleValidator bool) bool {
+	if nPeers == 0 {
+		return !isSoleValidator
 	}
 	if conR.catchUpLagThreshold <= 0 || maxPeerHeight == 0 {
 		return false
@@ -1131,10 +1137,9 @@ func ReactorMetrics(metrics *Metrics) ReactorOption {
 }
 
 // ReactorCatchupConfig configures the IsBehind heuristic that backs catching_up.
-func ReactorCatchupConfig(lagThreshold int64, minPeers int, debounce time.Duration) ReactorOption {
+func ReactorCatchupConfig(lagThreshold int64, debounce time.Duration) ReactorOption {
 	return func(conR *Reactor) {
 		conR.catchUpLagThreshold = lagThreshold
-		conR.minExpectedPeers = minPeers
 		conR.catchUpDebounce = debounce
 	}
 }

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -454,15 +454,13 @@ func (conR *Reactor) IsBehind() bool {
 func (conR *Reactor) isBehindRaw() bool {
 	peers := conR.Switch.Peers().List()
 
-	var maxPeerHeight int64
+	peerHeights := make([]int64, 0, len(peers))
 	for _, peer := range peers {
 		ps, ok := peer.Get(types.PeerStateKey).(*PeerState)
 		if !ok {
 			continue
 		}
-		if h := ps.GetHeight(); h > maxPeerHeight {
-			maxPeerHeight = h
-		}
+		peerHeights = append(peerHeights, ps.GetHeight())
 	}
 
 	// Sole-validator status is read live from consensus state on every call, so it
@@ -470,22 +468,37 @@ func (conR *Reactor) isBehindRaw() bool {
 	// without any cached value to update. (A node partitioned before a set change
 	// can't observe the other side's update, but that only makes it report behind,
 	// which is correct.)
-	return conR.evaluateBehind(conR.getRoundState().Height, maxPeerHeight, len(peers), conR.conS.isLocalSoleValidator())
+	return conR.evaluateBehind(conR.getRoundState().Height, peerHeights, conR.conS.isLocalSoleValidator())
 }
+
+// minCorroboratingPeers is the fewest connected peers required before peer-height
+// lag is trusted. Peer heights come from unverified gossip (NewRoundStepMessage), and
+// with a single peer that peer is a trivial "majority"; requiring at least two means
+// no single peer can drive catching_up on its own. Below this we can't corroborate, so
+// the height-lag check abstains (the zero-peer rule still covers the no-peer case).
+const minCorroboratingPeers = 2
 
 // evaluateBehind is the pure lag decision. With no peers we can't observe progress,
 // so we report behind unless this node can finalize on its own (it's the sole
 // validator); a non-validator or a validator in a larger set genuinely needs peers.
-// A zero threshold disables the height-lag check (the zero-peer rule still applies).
-// maxPeerHeight == 0 means no peer height learned yet.
-func (conR *Reactor) evaluateBehind(myHeight, maxPeerHeight int64, nPeers int, isSoleValidator bool) bool {
-	if nPeers == 0 {
+// Otherwise we report behind only when a majority of at least minCorroboratingPeers
+// connected peers report a height more than catchUpLagThreshold ahead of ours, so an
+// inflated height from a single peer (or a minority) can't drive the signal. A zero
+// threshold disables the height-lag check; the zero-peer rule still applies.
+func (conR *Reactor) evaluateBehind(myHeight int64, peerHeights []int64, isSoleValidator bool) bool {
+	if len(peerHeights) == 0 {
 		return !isSoleValidator
 	}
-	if conR.catchUpLagThreshold <= 0 || maxPeerHeight == 0 {
+	if conR.catchUpLagThreshold <= 0 || len(peerHeights) < minCorroboratingPeers {
 		return false
 	}
-	return maxPeerHeight-myHeight > conR.catchUpLagThreshold
+	ahead := 0
+	for _, h := range peerHeights {
+		if h-myHeight > conR.catchUpLagThreshold {
+			ahead++
+		}
+	}
+	return 2*ahead > len(peerHeights)
 }
 
 // applyDebounceLocked requires the lag condition to hold for catchUpDebounce before

--- a/consensus/reactor_catchup_test.go
+++ b/consensus/reactor_catchup_test.go
@@ -5,6 +5,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/p2p"
+	p2pmock "github.com/cometbft/cometbft/p2p/mock"
+	"github.com/cometbft/cometbft/types"
 )
 
 func TestEvaluateBehind(t *testing.T) {
@@ -42,6 +47,71 @@ func TestEvaluateBehind(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// peerWithHeight returns a mock peer carrying a consensus PeerState at height h.
+func peerWithHeight(h int64) *p2pmock.Peer {
+	p := p2pmock.NewPeer(nil)
+	ps := NewPeerState(p)
+	ps.PRS.Height = h
+	p.Set(types.PeerStateKey, ps)
+	return p
+}
+
+func TestCollectPeerHeights(t *testing.T) {
+	t.Run("no peers yields empty slice", func(t *testing.T) {
+		assert.Empty(t, collectPeerHeights(nil))
+	})
+
+	t.Run("collects every peer height in order", func(t *testing.T) {
+		peers := []p2p.Peer{peerWithHeight(100), peerWithHeight(110), peerWithHeight(90)}
+		assert.Equal(t, []int64{100, 110, 90}, collectPeerHeights(peers))
+	})
+
+	t.Run("skips peer without a PeerState", func(t *testing.T) {
+		peers := []p2p.Peer{peerWithHeight(100), p2pmock.NewPeer(nil), peerWithHeight(110)}
+		assert.Equal(t, []int64{100, 110}, collectPeerHeights(peers))
+	})
+
+	t.Run("skips peer with a non-PeerState value at the key", func(t *testing.T) {
+		bad := p2pmock.NewPeer(nil)
+		bad.Set(types.PeerStateKey, "not a peer state")
+		peers := []p2p.Peer{peerWithHeight(100), bad}
+		assert.Equal(t, []int64{100}, collectPeerHeights(peers))
+	})
+}
+
+func TestIsLocalSoleValidator(t *testing.T) {
+	val, _ := types.RandValidator(false, 10)
+	other, _ := types.RandValidator(false, 10)
+
+	tests := []struct {
+		name   string
+		pubKey crypto.PubKey
+		valSet *types.ValidatorSet
+		want   bool
+	}{
+		{"sole validator and we are it", val.PubKey, types.NewValidatorSet([]*types.Validator{val}), true},
+		{"sole validator but it is not us", other.PubKey, types.NewValidatorSet([]*types.Validator{val}), false},
+		{"we are in a larger set", val.PubKey, types.NewValidatorSet([]*types.Validator{val, other}), false},
+		{"no local validator key", nil, types.NewValidatorSet([]*types.Validator{val}), false},
+		{"no validator set", val.PubKey, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := &State{}
+			cs.privValidatorPubKey = tt.pubKey
+			cs.Validators = tt.valSet
+			assert.Equal(t, tt.want, cs.isLocalSoleValidator())
+		})
+	}
+}
+
+func TestReactorCatchupConfig(t *testing.T) {
+	conR := &Reactor{}
+	ReactorCatchupConfig(7, 3*time.Second)(conR)
+	assert.Equal(t, int64(7), conR.catchUpLagThreshold)
+	assert.Equal(t, 3*time.Second, conR.catchUpDebounce)
 }
 
 func TestApplyDebounce(t *testing.T) {

--- a/consensus/reactor_catchup_test.go
+++ b/consensus/reactor_catchup_test.go
@@ -12,28 +12,33 @@ func TestEvaluateBehind(t *testing.T) {
 		name            string
 		lagThreshold    int64
 		myHeight        int64
-		maxPeerHeight   int64
-		nPeers          int
+		peerHeights     []int64
 		isSoleValidator bool
 		want            bool
 	}{
-		{"peer far ahead", 5, 100, 110, 3, false, true},
-		{"peer ahead within threshold", 5, 100, 105, 3, false, false},
-		{"peer one over threshold", 5, 100, 106, 3, false, true},
-		{"equal height network halt", 5, 100, 100, 3, false, false},
-		{"round skew peer one ahead", 5, 100, 101, 3, false, false},
-		{"no peer height learned", 5, 100, 0, 3, false, false},
-		{"threshold disabled ignores lag", 0, 100, 999, 3, false, false},
-		{"sole validator zero peers healthy", 5, 100, 0, 0, true, false},
-		{"non-sole zero peers behind", 5, 100, 0, 0, false, true},
-		{"zero peers behind even when lag disabled", 0, 100, 0, 0, false, true},
+		{"majority far ahead", 5, 100, []int64{110, 110, 110}, false, true},
+		{"single peer ahead is minority", 5, 100, []int64{110, 100, 100}, false, false},
+		{"majority of three ahead", 5, 100, []int64{110, 110, 100}, false, true},
+		{"two peers split is not majority", 5, 100, []int64{110, 100}, false, false},
+		{"both peers ahead", 5, 100, []int64{110, 110}, false, true},
+		{"lone peer cannot corroborate", 5, 100, []int64{110}, false, false},
+		{"lone peer far ahead still cannot corroborate", 5, 100, []int64{100000}, false, false},
+		{"peers within threshold", 5, 100, []int64{105, 105, 105}, false, false},
+		{"majority one over threshold", 5, 100, []int64{106, 106, 106}, false, true},
+		{"equal height network halt", 5, 100, []int64{100, 100, 100}, false, false},
+		{"round skew one ahead", 5, 100, []int64{101, 101, 101}, false, false},
+		{"no peer height learned", 5, 100, []int64{0, 0, 0}, false, false},
+		{"threshold disabled ignores lag", 0, 100, []int64{999, 999, 999}, false, false},
+		{"sole validator zero peers healthy", 5, 100, nil, true, false},
+		{"non-sole zero peers behind", 5, 100, nil, false, true},
+		{"zero peers behind even when lag disabled", 0, 100, nil, false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conR := &Reactor{
 				catchUpLagThreshold: tt.lagThreshold,
 			}
-			got := conR.evaluateBehind(tt.myHeight, tt.maxPeerHeight, tt.nPeers, tt.isSoleValidator)
+			got := conR.evaluateBehind(tt.myHeight, tt.peerHeights, tt.isSoleValidator)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/consensus/reactor_catchup_test.go
+++ b/consensus/reactor_catchup_test.go
@@ -9,35 +9,31 @@ import (
 
 func TestEvaluateBehind(t *testing.T) {
 	tests := []struct {
-		name          string
-		lagThreshold  int64
-		minPeers      int
-		myHeight      int64
-		maxPeerHeight int64
-		nPeers        int
-		want          bool
+		name            string
+		lagThreshold    int64
+		myHeight        int64
+		maxPeerHeight   int64
+		nPeers          int
+		isSoleValidator bool
+		want            bool
 	}{
-		{"peer far ahead", 5, 0, 100, 110, 3, true},
-		{"peer ahead within threshold", 5, 0, 100, 105, 3, false},
-		{"peer exactly at threshold", 5, 0, 100, 105, 3, false},
-		{"peer one over threshold", 5, 0, 100, 106, 3, true},
-		{"equal height network halt", 5, 0, 100, 100, 3, false},
-		{"round skew peer one ahead", 5, 0, 100, 101, 3, false},
-		{"no peer height learned", 5, 0, 100, 0, 3, false},
-		{"threshold disabled ignores lag", 0, 0, 100, 999, 3, false},
-		{"single node zero peers healthy", 5, 0, 100, 0, 0, false},
-		{"min peers guard off with zero peers", 5, 0, 100, 100, 0, false},
-		{"min peers guard trips below min", 5, 2, 100, 100, 1, true},
-		{"min peers guard satisfied", 5, 2, 100, 100, 2, false},
-		{"min peers guard fires even when lag disabled", 0, 2, 100, 0, 0, true},
+		{"peer far ahead", 5, 100, 110, 3, false, true},
+		{"peer ahead within threshold", 5, 100, 105, 3, false, false},
+		{"peer one over threshold", 5, 100, 106, 3, false, true},
+		{"equal height network halt", 5, 100, 100, 3, false, false},
+		{"round skew peer one ahead", 5, 100, 101, 3, false, false},
+		{"no peer height learned", 5, 100, 0, 3, false, false},
+		{"threshold disabled ignores lag", 0, 100, 999, 3, false, false},
+		{"sole validator zero peers healthy", 5, 100, 0, 0, true, false},
+		{"non-sole zero peers behind", 5, 100, 0, 0, false, true},
+		{"zero peers behind even when lag disabled", 0, 100, 0, 0, false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conR := &Reactor{
 				catchUpLagThreshold: tt.lagThreshold,
-				minExpectedPeers:    tt.minPeers,
 			}
-			got := conR.evaluateBehind(tt.myHeight, tt.maxPeerHeight, tt.nPeers)
+			got := conR.evaluateBehind(tt.myHeight, tt.maxPeerHeight, tt.nPeers, tt.isSoleValidator)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/consensus/reactor_catchup_test.go
+++ b/consensus/reactor_catchup_test.go
@@ -5,7 +5,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	cfg "github.com/cometbft/cometbft/config"
+	cstypes "github.com/cometbft/cometbft/consensus/types"
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/p2p"
 	p2pmock "github.com/cometbft/cometbft/p2p/mock"
@@ -112,6 +115,56 @@ func TestReactorCatchupConfig(t *testing.T) {
 	ReactorCatchupConfig(7, 3*time.Second)(conR)
 	assert.Equal(t, int64(7), conR.catchUpLagThreshold)
 	assert.Equal(t, 3*time.Second, conR.catchUpDebounce)
+}
+
+// newCatchupReactor wires a Reactor with a non-started Switch carrying mock peers
+// at the given heights, a round state at myHeight, and (optionally) a single-validator
+// set that this node belongs to. catchUpDebounce is 0 so IsBehind reflects the raw
+// decision immediately, keeping the test free of timing.
+func newCatchupReactor(t *testing.T, myHeight int64, sole bool, peerHeights ...int64) *Reactor {
+	t.Helper()
+	cs := &State{}
+	if sole {
+		val, _ := types.RandValidator(false, 10)
+		cs.Validators = types.NewValidatorSet([]*types.Validator{val})
+		cs.privValidatorPubKey = val.PubKey
+	}
+	conR := &Reactor{
+		conS:                cs,
+		rs:                  &cstypes.RoundState{Height: myHeight},
+		catchUpLagThreshold: 5,
+		catchUpDebounce:     0,
+	}
+	conR.BaseReactor = *p2p.NewBaseReactor("Consensus", conR)
+
+	sw := p2p.NewSwitch(cfg.DefaultP2PConfig(), nil)
+	peerSet := sw.Peers().(*p2p.PeerSet)
+	for _, h := range peerHeights {
+		require.NoError(t, peerSet.Add(peerWithHeight(h)))
+	}
+	conR.SetSwitch(sw)
+	return conR
+}
+
+// TestIsBehindIntegration exercises the full IsBehind path (Switch peers ->
+// collectPeerHeights -> evaluateBehind, plus the sole-validator and debounce
+// wiring) rather than the pure decision helpers in isolation.
+func TestIsBehindIntegration(t *testing.T) {
+	t.Run("majority of peers ahead reports behind", func(t *testing.T) {
+		assert.True(t, newCatchupReactor(t, 100, false, 110, 110, 110).IsBehind())
+	})
+	t.Run("synced multi-peer network is not behind", func(t *testing.T) {
+		assert.False(t, newCatchupReactor(t, 100, false, 100, 100, 100).IsBehind())
+	})
+	t.Run("lone peer ahead cannot corroborate", func(t *testing.T) {
+		assert.False(t, newCatchupReactor(t, 100, false, 110).IsBehind())
+	})
+	t.Run("no peers and not sole validator is behind", func(t *testing.T) {
+		assert.True(t, newCatchupReactor(t, 100, false).IsBehind())
+	})
+	t.Run("no peers but sole validator is not behind", func(t *testing.T) {
+		assert.False(t, newCatchupReactor(t, 100, true).IsBehind())
+	})
 }
 
 func TestApplyDebounce(t *testing.T) {

--- a/consensus/reactor_catchup_test.go
+++ b/consensus/reactor_catchup_test.go
@@ -1,0 +1,81 @@
+package consensus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluateBehind(t *testing.T) {
+	tests := []struct {
+		name          string
+		lagThreshold  int64
+		minPeers      int
+		myHeight      int64
+		maxPeerHeight int64
+		nPeers        int
+		want          bool
+	}{
+		{"peer far ahead", 5, 0, 100, 110, 3, true},
+		{"peer ahead within threshold", 5, 0, 100, 105, 3, false},
+		{"peer exactly at threshold", 5, 0, 100, 105, 3, false},
+		{"peer one over threshold", 5, 0, 100, 106, 3, true},
+		{"equal height network halt", 5, 0, 100, 100, 3, false},
+		{"round skew peer one ahead", 5, 0, 100, 101, 3, false},
+		{"no peer height learned", 5, 0, 100, 0, 3, false},
+		{"threshold disabled ignores lag", 0, 0, 100, 999, 3, false},
+		{"single node zero peers healthy", 5, 0, 100, 0, 0, false},
+		{"min peers guard off with zero peers", 5, 0, 100, 100, 0, false},
+		{"min peers guard trips below min", 5, 2, 100, 100, 1, true},
+		{"min peers guard satisfied", 5, 2, 100, 100, 2, false},
+		{"min peers guard fires even when lag disabled", 0, 2, 100, 0, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conR := &Reactor{
+				catchUpLagThreshold: tt.lagThreshold,
+				minExpectedPeers:    tt.minPeers,
+			}
+			got := conR.evaluateBehind(tt.myHeight, tt.maxPeerHeight, tt.nPeers)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyDebounce(t *testing.T) {
+	debounce := 10 * time.Second
+	t0 := time.Now()
+
+	t.Run("not behind resets and returns false", func(t *testing.T) {
+		conR := &Reactor{catchUpDebounce: debounce, behindSince: t0}
+		assert.False(t, conR.applyDebounceLocked(false, t0.Add(time.Hour)))
+		assert.True(t, conR.behindSince.IsZero())
+	})
+
+	t.Run("behind but within debounce stays false", func(t *testing.T) {
+		conR := &Reactor{catchUpDebounce: debounce}
+		assert.False(t, conR.applyDebounceLocked(true, t0))
+		assert.False(t, conR.applyDebounceLocked(true, t0.Add(5*time.Second)))
+	})
+
+	t.Run("behind past debounce flips true", func(t *testing.T) {
+		conR := &Reactor{catchUpDebounce: debounce}
+		assert.False(t, conR.applyDebounceLocked(true, t0))
+		assert.True(t, conR.applyDebounceLocked(true, t0.Add(debounce)))
+	})
+
+	t.Run("transient blip resets the timer", func(t *testing.T) {
+		conR := &Reactor{catchUpDebounce: debounce}
+		assert.False(t, conR.applyDebounceLocked(true, t0))
+		assert.False(t, conR.applyDebounceLocked(false, t0.Add(5*time.Second)))
+		// timer restarts; not yet past debounce from the new start.
+		assert.False(t, conR.applyDebounceLocked(true, t0.Add(6*time.Second)))
+		assert.True(t, conR.applyDebounceLocked(true, t0.Add(16*time.Second)))
+	})
+
+	t.Run("zero debounce flips immediately", func(t *testing.T) {
+		conR := &Reactor{catchUpDebounce: 0}
+		assert.True(t, conR.applyDebounceLocked(true, t0))
+	})
+}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2727,6 +2727,20 @@ func (cs *State) updatePrivValidatorPubKey() error {
 	return nil
 }
 
+// isLocalSoleValidator reports whether this node is the only validator in the
+// current set, i.e. it can finalize blocks on its own and so does not need peers
+// to make progress. Uses the same local-validator membership test as the signing
+// path (Validators.HasAddress on the private validator's address), so a
+// non-validator full node always returns false.
+func (cs *State) isLocalSoleValidator() bool {
+	cs.mtx.RLock()
+	defer cs.mtx.RUnlock()
+	if cs.privValidatorPubKey == nil || cs.Validators == nil {
+		return false
+	}
+	return cs.Validators.Size() == 1 && cs.Validators.HasAddress(cs.privValidatorPubKey.Address())
+}
+
 // look back to check existence of the node's consensus votes before joining consensus
 func (cs *State) checkDoubleSigningRisk(height int64) error {
 	if cs.privValidator != nil && cs.privValidatorPubKey != nil && cs.config.DoubleSignCheckHeight > 0 && height > 0 {

--- a/inspect/rpc/rpc.go
+++ b/inspect/rpc/rpc.go
@@ -86,6 +86,10 @@ func (waitSyncCheckerImpl) WaitSync() bool {
 	return false
 }
 
+func (waitSyncCheckerImpl) IsBehind() bool {
+	return false
+}
+
 // ListenAndServe listens on the address specified in srv.Addr and handles any
 // incoming requests over HTTP using the Inspector rpc handler specified on the server.
 func (srv *Server) ListenAndServe(ctx context.Context) error {

--- a/inspect/rpc/rpc_test.go
+++ b/inspect/rpc/rpc_test.go
@@ -1,0 +1,15 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The offline inspect server has no live consensus reactor, so it always reports
+// fully synced: never waiting on block-sync and never behind its peers.
+func TestWaitSyncCheckerReportsSynced(t *testing.T) {
+	checker := waitSyncCheckerImpl{}
+	assert.False(t, checker.WaitSync())
+	assert.False(t, checker.IsBehind())
+}

--- a/node/setup.go
+++ b/node/setup.go
@@ -331,7 +331,12 @@ func createConsensusReactor(config *cfg.Config,
 	if privValidator != nil {
 		consensusState.SetPrivValidator(privValidator)
 	}
-	consensusReactor := cs.NewReactor(consensusState, waitSync, cs.ReactorMetrics(csMetrics))
+	consensusReactor := cs.NewReactor(consensusState, waitSync, cs.ReactorMetrics(csMetrics),
+		cs.ReactorCatchupConfig(
+			config.Consensus.CatchupLagThreshold,
+			config.Consensus.MinExpectedPeers,
+			config.Consensus.CatchupDebounceDuration,
+		))
 	consensusReactor.SetLogger(consensusLogger)
 	// services which will be publishing and/or subscribing for messages (events)
 	// consensusReactor will set it on consensusState and blockExecutor

--- a/node/setup.go
+++ b/node/setup.go
@@ -334,7 +334,6 @@ func createConsensusReactor(config *cfg.Config,
 	consensusReactor := cs.NewReactor(consensusState, waitSync, cs.ReactorMetrics(csMetrics),
 		cs.ReactorCatchupConfig(
 			config.Consensus.CatchupLagThreshold,
-			config.Consensus.MinExpectedPeers,
 			config.Consensus.CatchupDebounceDuration,
 		))
 	consensusReactor.SetLogger(consensusLogger)

--- a/rpc/core/env.go
+++ b/rpc/core/env.go
@@ -59,6 +59,7 @@ type peers interface {
 
 type consensusReactor interface {
 	WaitSync() bool
+	IsBehind() bool
 }
 
 // ----------------------------------------------

--- a/rpc/core/status.go
+++ b/rpc/core/status.go
@@ -62,7 +62,7 @@ func (env *Environment) Status(*rpctypes.Context) (*ctypes.ResultStatus, error) 
 			EarliestAppHash:     earliestAppHash,
 			EarliestBlockHeight: earliestBlockHeight,
 			EarliestBlockTime:   time.Unix(0, earliestBlockTimeNano),
-			CatchingUp:          env.ConsensusReactor.WaitSync(),
+			CatchingUp:          env.ConsensusReactor.WaitSync() || env.ConsensusReactor.IsBehind(),
 		},
 		ValidatorInfo: ctypes.ValidatorInfo{
 			Address:     env.PubKey.Address(),


### PR DESCRIPTION
## Summary

`/status`'s `catching_up` is derived solely from the consensus reactor's `WaitSync()` latch. `WaitSync` is set once at startup and cleared the first time the node switches from block-sync to the consensus reactor, after which it stays `false` for the rest of the process. So the field only ever reflects the *initial* block-sync and never reflects a node that **later** stops making progress relative to its peers — that node keeps answering `catching_up=false` even while it has fallen well behind, and anything that reads the field as a readiness/health signal (load balancers, k8s probes, dashboards, and in-process consumers) treats it as fully synced.

This PR adds `Reactor.IsBehind()`, evaluated from peer-reported heights, and folds it into the field:

```
CatchingUp = WaitSync() || IsBehind()
```

`IsBehind()` is `true` when a **majority of at least two connected peers** report a height more than `catchup_lag_threshold` blocks ahead of our consensus height, or when the node has **no peers and is not the sole validator** (it cannot make progress on its own, so it cannot establish that it is current).

It uses **peer heights, not local block-time staleness**, on purpose. A bare staleness check cannot distinguish:
- a node that is genuinely behind its peers (some peer reports a greater height) — which *is* catching up, from
- a network in which every node has legitimately stopped at the same height (no peer is ahead) — which is **not** catching up.

Reporting the second case as catching up would be a false positive, so height comparison is the discriminator rather than "my last block is old".

Peer heights are **unverified gossip** (`NewRoundStepMessage`; `ValidateBasic` checks shape only), so the lag decision requires a **majority of at least two** connected peers to corroborate it rather than trusting a single peer's max — no single peer (and no lone peer, which can't corroborate) advertising an inflated height can drive the signal (see Known limitations).

The **zero-peer case is self-determining** (no configuration): a node with no peers reports `catching_up=true` unless it is the only validator in the set, in which case it finalizes blocks on its own and needs no peers. Sole-validator status uses the same local-validator membership test as the signing path and is read live from consensus state, so it follows validator-set changes the node has committed into local round state and behaves identically on mainnet, testnet, and local devnets — no network-specific config, and the scenario is testable on any kurtosis network id.

A short **debounce** (`catchup_debounce_duration`) requires the lag condition to hold continuously before `catching_up` flips to `true`, damping flapping at the threshold boundary; the transition back to `false` is immediate.

### New `[consensus]` config (defaults)

| Key | Default | Notes |
|---|---|---|
| `catchup_lag_threshold` | `5` | Blocks ahead a peer must be to count as reporting us behind; a **majority of at least two** connected peers must agree before we report behind. `0` disables peer-height lag detection only — the zero-peer rule still applies. Must be `>=2` when enabled, to absorb the normal one-height round skew between synced peers. |
| `catchup_debounce_duration` | `10s` | How long the lag condition must hold before flipping to `true`. |

Both are additive with their defaults; behaviour only changes once a majority of (≥2) peers are `>threshold` ahead, or the node has no peers while other validators exist. The zero-peer rule needs no config.

## Implementation notes / design decisions

- **Fixed at the reactor, OR'd into `status.go`.** `IsBehind()` is a new read-only method on `*Reactor`; the RPC `consensusReactor` interface gains it and `Status` ORs it into `CatchingUp`.
- **`WaitSync` is left untouched.** It also gates consensus message handling (`reactor.go` channel handlers), so re-arming it to express "behind" would disable consensus rather than just relabel health. `IsBehind()` is therefore a separate signal.
- **Majority-of-≥2 corroboration, not raw max.** Peer heights are untrusted gossip, so `evaluateBehind` trips only when more than half of the connected peers are beyond the threshold *and* there are at least `minCorroboratingPeers` (2) of them — a lone peer is a trivial "majority", so it's excluded. This is fail-safe (the signal can only over-report "catching up", never forge progress) and removes the single-peer lever.
- **Zero-peer handling is self-determining, not configured.** A node with no peers reports behind unless it is the sole validator (`State.isLocalSoleValidator`, the same membership test as the signing path). No per-network configuration; testable on any devnet regardless of chain id; a non-validator node has no private validator and so always needs peers.
- **Decision logic is split into pure helpers** (`evaluateBehind`, `applyDebounceLocked`, `collectPeerHeights`) so the branching and the peer-height aggregation are unit-testable without p2p plumbing; `isBehindRaw` only wires them to the live `Switch` peers and the sole-validator flag.
- **Offline `inspect` server** stubs `IsBehind() => false`.

## Executed tests

### Unit (`consensus/reactor_catchup_test.go`, `config/config_test.go`, `inspect/rpc/rpc_test.go`)
- `evaluateBehind` — majority far ahead, single peer is a minority, majority of three, two-peer split, both-of-two ahead, lone peer cannot corroborate (incl. far ahead), within threshold, one over threshold, equal height (network halt), one-height round skew, no peer height learned, threshold disabled, sole-validator zero-peer, non-sole zero-peer, zero-peer behind with lag disabled.
- `applyDebounceLocked` — within-debounce stays false, past-debounce flips true, transient blip resets the timer, zero-debounce immediate, not-behind resets state.
- `collectPeerHeights` — collects every height in order, no peers → empty, skips a peer with no `PeerState`, skips a peer with a wrong-type value at the key (covers the aggregation loop + the `peer.Get(...)` assertion).
- `isLocalSoleValidator` — sole & we're it, sole but not us, larger set, nil key, nil validator set.
- `ReactorCatchupConfig` — option setter assigns lag threshold + debounce.
- `ConsensusConfig.ValidateBasic` — `catchup_lag_threshold` 0 / 1 / 2 / negative, `catchup_debounce_duration` zero / negative; plus the shipped defaults (`5`, `10s`).
- offline `inspect` checker — `WaitSync` / `IsBehind` both report synced.

### Integration
- `TestIsBehindIntegration` drives the full `IsBehind()` path through a (non-started) `Switch` populated with mock peers + a minimal `State` (debounce 0): majority of peers ahead → behind; synced multi-peer → not behind; lone peer ahead → not behind; zero-peer non-sole → behind; zero-peer sole → not behind.

### Mutation
- `diffguard --base develop` (diff mode — mutates only the changed functions across the touched files, including `status.go`): **100% (47/47)**, tier-1 logic 100%, tier-2 100%, tier-3 100%. Adding the direct `ReactorCatchupConfig` test also removed a flake where that mutant's kill depended on a flaky consensus-suite test and flip-flopped between runs. (diffguard's overall verdict still reports FAIL on pre-existing items not introduced here: `consensus/reactor.go` is a 2066-line upstream file over the 500-line cap, plus churn/SDP warnings on upstream code.)

### End-to-end (Kurtosis, 5-validator devnet)
- Built this branch into a Heimdall `v0.7.1` image and spawned a 5-validator devnet. Isolated one validator's Heimdall P2P: after cometbft evicted the now-dead peers to 0, `catching_up` flipped `true` (zero-peer rule); on reconnect the node reported `true` while blocksyncing ~100 blocks behind its peers (lag branch), then returned to `false` once it caught up. The control node reported `catching_up=false` throughout — no false positive. Recovery was automatic on heal.

### Build / lint
- `go build ./consensus/... ./config/... ./rpc/... ./node/... ./inspect/...` — clean.
- `go test ./consensus/ ./config/ ./node/ ./inspect/rpc/` — pass. `gofmt -l` — clean. `golangci-lint` / `gofumpt` / diffguard mutation enforced by CI.

## Rollout notes

- **Not consensus-affecting.** This relabels a reported `/status` field; it does not change block validity, state transition, app hash, or wire format.
- **Backward-compatible.** Defaults leave `catching_up` unchanged for synced nodes; single-validator / single-node deployments are unaffected (the sole validator advances without peers).
- **No configuration required.** The zero-peer behavior ships in the binary and is identical across networks; operators only need config work if they want to *tune* `catchup_lag_threshold` / `catchup_debounce_duration` away from the defaults.

## Known limitations

- **Peer heights are unverified and only as fresh as gossip.** They come from `NewRoundStepMessage` (`ValidateBasic` checks shape only), so they are not proof a peer committed/verified those blocks, and a peer that stays connected but stops sending round-step updates (e.g. a half-open TCP connection before p2p eviction) leaves a stale height until eviction. The signal is fail-safe (it can only push `catching_up` toward `true` / not-ready, never forge progress or admit invalid blocks), and the **majority-of-≥2 requirement** means a single (or minority of) misbehaving peer — or a lone peer — cannot drive it. The residual is an attacker controlling a majority of a node's *direct* peers (eclipse-level) — but a validator's direct peers in the recommended sentry topology are its own operator-run sentries; the exposed surface is open-peering (`pex=true`) RPC/full nodes, where the impact is availability only. A verified / quorum-of-voting-power height would be stronger but amounts to re-deriving block-sync, so it's out of scope here.
- **Detection latency on a sudden isolation is bounded by p2p peer eviction, not the debounce.** Observed in the e2e run above: after a hard network cut, cometbft kept the dead peer entries (frozen at the same height, so not *ahead*) for ~99s before evicting them to 0, so `catching_up` flipped ~1.5 min after the cut (eviction + the 10s debounce), not seconds. This is fail-safe, but it bounds how quickly a downstream consumer (e.g. a Bor seal-gate) can react to an abrupt isolation; tightening it would mean tuning the p2p liveness timeouts, which is out of scope here.
- **`IsBehind()` is read-triggered.** The debounce state advances on `/status` reads, so a sparse poller can under-report sustained lag until a second poll occurring at least `catchup_debounce_duration` after the first lagging observation. Reactor-side sampling/caching is a possible follow-up if `/status` semantics need to be wall-clock accurate independent of callers.
- With fewer than two connected peers, or when no majority of peers reports a height ahead of ours, the node is treated as not-behind (the zero-peer / sole-validator rule still covers the no-peer case).

## Open design decisions (feedback wanted)

1. **`catchup_lag_threshold` default (`5`).** Right value? And should the threshold be **height-based** (current) or **time-derived** (e.g. "behind by more than N block-times")? Height-based is deterministic and simpler; time-based is more portable across block-time configs.
2. ~~**`min_expected_peers` default.**~~ **Resolved** — replaced with the self-determining sole-validator rule above (no config knob), chosen so the zero-peer scenario is testable on any kurtosis network id rather than hardcoding network names.
3. **`catchup_debounce_duration` default (`10s`).** Worth tuning against typical block time; also whether the debounce should be symmetric (currently fast-to-recover, slow-to-assert).
4. **External authoritative height.** For forks that have a stronger external height signal (e.g. a checkpoint-derived height), should `IsBehind()` optionally accept that as an additional input, or is that better layered downstream of this method?
5. **Surface area.** Should "behind" also be exposed as its own `/status` field and/or a metric, in addition to folding into `catching_up`, so consumers can distinguish "initial block-sync" from "fell behind after sync"?
6. **`minCorroboratingPeers` (`2`).** Hardcoded minimum peers before peer-height lag is trusted. Is `2` right, or should it be higher (e.g. `3`) for stronger corroboration on well-connected nodes?

> Part of a broader reliability effort; downstream wiring/tuning lands separately. End-to-end partition validation: see the Executed tests section.