### PR TITLE
chore(ci): bump codegenie to v0.5.5

### DIFF
--- a/.github/workflows/codegenie-review.yml
+++ b/.github/workflows/codegenie-review.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: 0xPolygon/codegenie@v0.5.1
+      - uses: 0xPolygon/codegenie@v0.5.5
         with:
           model: "anthropic/claude-opus-5:high"
           llm-api-key: ${{ secrets.CLAUDE_API_KEY }}


### PR DESCRIPTION
## Summary
Bumps the CodeGenie GitHub Action from v0.5.1 to v0.5.5 so on-demand review runs use the latest release.

## Executed tests
- git diff --check
- Verified the v0.5.5 tag resolves to commit e0c4ddad53c821f3dad4fdb95eba585bdf6a47fc

## Rollout notes
CI-only and backwards-compatible. No consensus, coordinated-upgrade, or operator impact.